### PR TITLE
fix: 'ColorFormatter' object has no attribute '_style'

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ echo_kwargs = {
     'exception': dict(err=True),
     'critical': dict(err=True),
 }
-click_logging.basic_config(logger, echo_kwargs=True)
+click_logging.basic_config(logger, echo_kwargs=echo_kwargs)
 ```
 
 Fork

--- a/click_logging/core.py
+++ b/click_logging/core.py
@@ -76,10 +76,10 @@ def _normalize_style_kwargs(styles):
 
 
 def _normalize_echo_kwargs(echo_kwargs):
-    normamized_echo_kwargs = dict()
+    normalized_echo_kwargs = dict()
     if echo_kwargs:
-        normamized_echo_kwargs.update(echo_kwargs)
-    return normamized_echo_kwargs
+        normalized_echo_kwargs.update(echo_kwargs)
+    return normalized_echo_kwargs
 
 
 def basic_config(logger=None, style_kwargs=None, echo_kwargs=None):

--- a/click_logging/core.py
+++ b/click_logging/core.py
@@ -25,6 +25,7 @@ def _meta():
 class ColorFormatter(logging.Formatter):
     def __init__(self, style_kwargs):
         self.style_kwargs = style_kwargs
+        super().__init__()
 
     def format(self, record):
         if not record.exc_info:
@@ -35,7 +36,7 @@ class ColorFormatter(logging.Formatter):
                                      **self.style_kwargs[level])
                 msg = '\n'.join(prefix + x for x in msg.splitlines())
             return msg
-        return logging.Formatter.format(self, record)
+        return super().format(record)
 
 
 class ClickHandler(logging.Handler):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -103,3 +103,20 @@ def test_logging_args(runner):
 
     result = runner.invoke(cli, ['-v', 'debug'])
     assert 'debug: hello world' in result.output
+
+def test_logging_exception(runner):
+    @click.command()
+    @click_logging.simple_verbosity_option(test_logger)
+    def cli():
+        try:
+            1/0
+        except ZeroDivisionError:
+            test_logger.exception('Uh oh.')
+
+    result = runner.invoke(cli, ['-v', 'debug'])
+
+    # to catch regressions for "AttributeError: 'ColorFormatter' object has no attribute '_style'"
+    assert "AttributeError" not in result.output
+
+    assert 'Uh oh.' in result.output
+    assert 'ZeroDivisionError:' in result.output


### PR DESCRIPTION
1. Added `super` `__init__()` & `format()` calls to `ColorFormatter`. Without this I was getting an unhandled exception when calling `logger.exception`:

```
import logging, click_logging, click
logger = logging.getLogger('foo')
click_logging.basic_config(logger)
try:
    1/0
except Exception as exc:
    logger.exception("Exception.")
```

    --- Logging error ---
    Traceback (most recent call last):
      File "x.py", line 11, in <module>
        1/0
    ZeroDivisionError: division by zero

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "env/lib/python3.8/site-packages/click_logging/core.py", line 49, in emit
        msg = self.format(record)
      File "/usr/lib/python3.8/logging/__init__.py", line 929, in format
        return fmt.format(record)
      File "env/lib/python3.8/site-packages/click_logging/core.py", line 39, in format
        return logging.Formatter.format(self, record)
      File "/usr/lib/python3.8/logging/__init__.py", line 669, in format
        if self.usesTime():
      File "/usr/lib/python3.8/logging/__init__.py", line 637, in usesTime
        return self._style.usesTime()
    AttributeError: 'ColorFormatter' object has no attribute '_style'
    Call stack:
      File "x.py", line 13, in <module>
        logger.exception("Exception.")
      File "/usr/lib/python3.8/logging/__init__.py", line 1481, in exception
        self.error(msg, *args, exc_info=exc_info, **kwargs)
      File "/usr/lib/python3.8/logging/__init__.py", line 1475, in error
        self._log(ERROR, msg, args, **kwargs)
      File "/usr/lib/python3.8/logging/__init__.py", line 1589, in _log
        self.handle(record)
      File "/usr/lib/python3.8/logging/__init__.py", line 1599, in handle
        self.callHandlers(record)
      File "/usr/lib/python3.8/logging/__init__.py", line 1661, in callHandlers
        hdlr.handle(record)
      File "/usr/lib/python3.8/logging/__init__.py", line 954, in handle
        self.emit(record)
      File "env/lib/python3.8/site-packages/click_logging/core.py", line 56, in emit
        self.handleError(record)
    Message: 'Exception.'
    Arguments: ()

2. Fixed `echo_kwargs` example in the README.
3. Fixed a typo in the variable named `normamized_echo_kwargs`.